### PR TITLE
DUI 코어컴포넌트 : AppBar 개발

### DIFF
--- a/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/component/appbar/DodamAppBar.kt
+++ b/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/component/appbar/DodamAppBar.kt
@@ -1,0 +1,107 @@
+package kr.hs.dgsw.smartschool.components.component.appbar
+
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import kr.hs.dgsw.smartschool.components.foundation.Text
+import kr.hs.dgsw.smartschool.components.modifier.dodamClickable
+import kr.hs.dgsw.smartschool.components.theme.DodamTheme
+import kr.hs.dgsw.smartschool.components.theme.IcBackArrow
+import kr.hs.dgsw.smartschool.components.theme.IcDelete
+import kr.hs.dgsw.smartschool.components.theme.IcUser
+import kr.hs.dgsw.smartschool.components.utlis.DodamDimen
+
+@Composable
+fun DodamAppBar(
+    onStartIconClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = DodamTheme.color.White,
+    startIcon: (@Composable () -> Unit)? = null,
+    endContents: (@Composable RowScope.() -> Unit)? = null,
+    title: String? = null,
+    titleStyle: TextStyle = DodamTheme.typography.title2.copy(fontWeight = FontWeight.Medium),
+) {
+    Row(
+        modifier = modifier
+            .background(color = backgroundColor)
+            .fillMaxWidth()
+            .height(DodamDimen.AppBarHeight)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(horizontal = DodamDimen.AppBarDefaultContentSpace)
+                .dodamClickable(rippleEnable = false) {
+                    onStartIconClick()
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            startIcon?.let {
+                it()
+            } ?: IcBackArrow(
+                    modifier = Modifier
+                        .size(DodamDimen.AppBarDefaultIconSize),
+                    tint = DodamTheme.color.Black,
+                    contentDescription = null,
+                )
+        }
+        title?.let {
+            Text(
+                text = it,
+                style = titleStyle,
+                modifier = Modifier.align(Alignment.CenterVertically)
+            )
+        }
+
+        endContents?.let {
+            Row(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(end = DodamDimen.AppBarDefaultContentSpace)
+                    .weight(1f),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                it()
+            }
+        }
+
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewDodamAppBar() {
+    Column {
+        DodamAppBar(
+            onStartIconClick = { Log.d("PreviewAppBarTest", "Click!") },
+            title = "알림",
+            endContents = { AppBarSampleEndContents() }
+        )
+    }
+}
+
+@Composable
+private fun RowScope.AppBarSampleEndContents() {
+    IcDelete(
+        contentDescription = null,
+        modifier = Modifier
+            .align(Alignment.CenterVertically)
+            .size(DodamDimen.AppBarDefaultIconSize)
+    )
+}

--- a/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/component/appbar/DodamAppBar.kt
+++ b/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/component/appbar/DodamAppBar.kt
@@ -24,7 +24,6 @@ import kr.hs.dgsw.smartschool.components.modifier.dodamClickable
 import kr.hs.dgsw.smartschool.components.theme.DodamTheme
 import kr.hs.dgsw.smartschool.components.theme.IcBackArrow
 import kr.hs.dgsw.smartschool.components.theme.IcDelete
-import kr.hs.dgsw.smartschool.components.theme.IcUser
 import kr.hs.dgsw.smartschool.components.utlis.DodamDimen
 
 @Composable
@@ -55,11 +54,11 @@ fun DodamAppBar(
             startIcon?.let {
                 it()
             } ?: IcBackArrow(
-                    modifier = Modifier
-                        .size(DodamDimen.AppBarDefaultIconSize),
-                    tint = DodamTheme.color.Black,
-                    contentDescription = null,
-                )
+                modifier = Modifier
+                    .size(DodamDimen.AppBarDefaultIconSize),
+                tint = DodamTheme.color.Black,
+                contentDescription = null,
+            )
         }
         title?.let {
             Text(
@@ -80,7 +79,6 @@ fun DodamAppBar(
                 it()
             }
         }
-
     }
 }
 

--- a/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/theme/DodamIcon.kt
+++ b/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/theme/DodamIcon.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.res.painterResource
 import kr.hs.dgsw.smartschool.components.foundation.Icon
 import kr.hs.smartschool.components.R
 
-
 @Composable
 fun IcBackArrow(
     contentDescription: String?,

--- a/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/theme/DodamIcon.kt
+++ b/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/theme/DodamIcon.kt
@@ -8,6 +8,21 @@ import androidx.compose.ui.res.painterResource
 import kr.hs.dgsw.smartschool.components.foundation.Icon
 import kr.hs.smartschool.components.R
 
+
+@Composable
+fun IcBackArrow(
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_back_arrow),
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint
+    )
+}
+
 @Composable
 fun IcLeftArrow(
     contentDescription: String?,

--- a/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/utlis/DodamDimen.kt
+++ b/dodam-components/src/main/java/kr/hs/dgsw/smartschool/components/utlis/DodamDimen.kt
@@ -7,4 +7,8 @@ object DodamDimen {
     val ScreenSidePadding = 16.dp
 
     val CardSidePadding = 18.dp
+
+    val AppBarHeight = 45.dp
+    val AppBarDefaultContentSpace = 14.dp
+    val AppBarDefaultIconSize = 20.dp
 }

--- a/dodam-components/src/main/res/drawable/ic_back_arrow.xml
+++ b/dodam-components/src/main/res/drawable/ic_back_arrow.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9.569,18.82C9.379,18.82 9.189,18.75 9.039,18.6L2.969,12.53C2.679,12.24 2.679,11.76 2.969,11.47L9.039,5.4C9.329,5.11 9.809,5.11 10.099,5.4C10.389,5.69 10.389,6.17 10.099,6.46L4.559,12L10.099,17.54C10.389,17.83 10.389,18.31 10.099,18.6C9.959,18.75 9.759,18.82 9.569,18.82Z"
+      android:fillColor="#292D32"/>
+  <path
+      android:pathData="M20.5,12.75H3.67C3.26,12.75 2.92,12.41 2.92,12C2.92,11.59 3.26,11.25 3.67,11.25H20.5C20.91,11.25 21.25,11.59 21.25,12C21.25,12.41 20.91,12.75 20.5,12.75Z"
+      android:fillColor="#292D32"/>
+</vector>


### PR DESCRIPTION
## 개요
상단에서 Navigation, Title 등의 역할을 하는 AppBar를 개발했습니다.

## 작업 사항
* 디자인 사항 정리
* AppBar 구역 나누기
* AppBar 공통 Dimens 정의
* AppBar 구현
* Preview 테스트

## Design
<img width="442" alt="image" src="https://user-images.githubusercontent.com/80940200/216757989-9284fdef-6da9-439f-b8e3-85d962c5e2ee.png">


## Screen
<img src = https://user-images.githubusercontent.com/80940200/216757955-6905dec2-ee77-4bef-9527-ce074ddd8b95.png width=360 />

## 기타 사항
AppBar는 3가지 구역으로 나뉩니다.
1. StartIcon : 기본 값인 null을 주면 자동으로 Back Button이 들어갑니다.
2. Title : StartIcon 옆에 붙습니다.
3. EndContents : 남은 구역을 자유롭게 사용합니다.

Height -> 45.dp